### PR TITLE
fix: avoid race condition when downloading files using zip files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ master ]
+
+permissions:
+  contents: read
+
+jobs:
+  linter:
+    name: Linter on a PR
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: Scalingo/actions/go-linter@main
+        with:
+          working-directory: support/kmsbp
+  tests:
+    name: Unit Tests
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: Scalingo/actions/go-tests@main
+        with:
+          working-directory: support/kmsbp

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ This buildpack uses the following environment variables:
 
 The `OBJECTS` and `FILES` are two comma separated strings representing the objects to download from S3 and their filenames on the hardrive.
 
+By default, each `OBJECTS` entry is treated as a plain S3 object key.
+You can also extract a file from a zip object with this syntax:
+
+```
+<zip-object>:<path-inside-zip>
+```
+
+For example, `secrets/bundle.zip:tls/server.crt` means:
+download `secrets/bundle.zip` from S3, then extract `tls/server.crt` from that zip and write it to the matching `FILES` path.
+
 If we have the following configuration:
 
 ```
@@ -28,3 +38,10 @@ FILES=1.txt,2.txt,3.txt
 ```
 
 The buildpack will download the object `a` from S3 and store it in the `$CERTS_INSTALL_PATH/1.txt` file, store the `b` object to `$CERTS_INSTALL_PATH/2.txt` and store the `c` object to `$CERTS_INSTALL_PATH/3.txt`.
+
+Mixed example with both plain objects and zip entries:
+
+```
+OBJECTS=certs/root.crt,secrets/bundle.zip:tls/server.crt
+FILES=root.crt,server.crt
+```

--- a/support/kmsbp/go.mod
+++ b/support/kmsbp/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/aws-kms-buildpack/kmsbp
 
-go 1.25
+go 1.25.0
 
 require github.com/aws/aws-sdk-go-v2 v0.10.0
 

--- a/support/kmsbp/kmsbp.go
+++ b/support/kmsbp/kmsbp.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"archive/zip"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -15,8 +17,23 @@ import (
 )
 
 var (
-	needed = []string{"KMSBP_AWS_BUCKET", "KMSBP_AWS_REGION", "KMSBP_AWS_ID", "KMSBP_AWS_TOKEN", "CERTS_INSTALL_PATH", "OBJECTS", "FILES"}
+	needed = []string{"KMSBP_AWS_BUCKET", "KMSBP_AWS_REGION", "KMSBP_AWS_ID", "KMSBP_AWS_TOKEN", "CERTS_INSTALL_PATH", "OBJECTS", "FILES", "BUILD_DIR"}
 )
+
+const zipSpecSeparator = ":"
+
+const maxZipEntrySizeBytes uint64 = 32 * 1024 * 1024
+
+type downloadItem struct {
+	dest  string
+	obj   string
+	entry string
+}
+
+type downloadPlan struct {
+	plain map[string]string
+	zips  map[string][]downloadItem
+}
 
 func main() {
 	validateEnv()
@@ -24,7 +41,7 @@ func main() {
 	files := strings.Split(os.Getenv("FILES"), ",")
 
 	if len(objects) != len(files) {
-		log.Println("FILES length is not the same as OBEJCTS length")
+		log.Println("FILES length is not the same as OBJECTS length")
 		os.Exit(-1)
 	}
 
@@ -38,32 +55,229 @@ func main() {
 		os.Exit(-1)
 	}
 
+	plan, err := buildDownloadPlan(objects, files, basePath)
+	if err != nil {
+		log.Println(err)
+		os.Exit(-1)
+	}
+
 	downloader := s3manager.NewDownloader(awsConfig())
-	for i, object := range objects {
-		err := download(downloader, filepath.Join(basePath, files[i]), object)
-		if err != nil {
-			log.Println("fail to download object", object)
-			os.Exit(-1)
-		}
+
+	err = executePlan(downloader, plan)
+	if err != nil {
+		log.Println(err)
+		os.Exit(-1)
 	}
 }
 
-func download(downloader *s3manager.Downloader, dest string, object string) error {
+func buildDownloadPlan(objectSpecs, fileDestinations []string, basePath string) (*downloadPlan, error) {
+	plan := &downloadPlan{
+		plain: make(map[string]string),
+		zips:  make(map[string][]downloadItem),
+	}
+
+	for i, spec := range objectSpecs {
+		spec = strings.TrimSpace(spec)
+		dest := strings.TrimSpace(fileDestinations[i])
+		fullDest := filepath.Join(basePath, dest)
+
+		objectKey, zipEntry, isZipEntry, err := parseObjectSpec(spec)
+		if err != nil {
+			return nil, err
+		}
+
+		if isZipEntry {
+			plan.zips[objectKey] = append(plan.zips[objectKey], downloadItem{
+				dest:  fullDest,
+				obj:   objectKey,
+				entry: zipEntry,
+			})
+		} else {
+			if existing, ok := plan.plain[objectKey]; ok && existing != fullDest {
+				return nil, fmt.Errorf("object %q mapped to different destinations: %q and %q", objectKey, existing, fullDest)
+			}
+			plan.plain[objectKey] = fullDest
+		}
+	}
+
+	return plan, nil
+}
+
+func parseObjectSpec(spec string) (string, string, bool, error) {
+	parts := strings.SplitN(spec, zipSpecSeparator, 2)
+	if len(parts) == 1 {
+		return spec, "", false, nil
+	}
+
+	object := strings.TrimSpace(parts[0])
+	entry := strings.TrimSpace(parts[1])
+	if object == "" || entry == "" {
+		return "", "", false, fmt.Errorf("invalid object spec %q (expected <object> or <zip-object>%s<entry>)", spec, zipSpecSeparator)
+	}
+
+	return object, entry, true, nil
+}
+
+func executePlan(downloader *s3manager.Downloader, plan *downloadPlan) error {
+	for objectKey, dest := range plan.plain {
+		err := downloadRawObject(downloader, dest, objectKey)
+		if err != nil {
+			return fmt.Errorf("failed to download object %q: %w", objectKey, err)
+		}
+	}
+
+	for zipObject, items := range plan.zips {
+		tmpPath, err := downloadZipTempFile(downloader, zipObject)
+		if err != nil {
+			return err
+		}
+		defer func(path string) {
+			removeErr := os.Remove(path)
+			if removeErr != nil && !os.IsNotExist(removeErr) {
+				log.Printf("failed to remove temporary zip file %q: %v", path, removeErr)
+			}
+		}(tmpPath)
+
+		err = extractZipEntries(tmpPath, items)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func downloadRawObject(downloader *s3manager.Downloader, dest, object string) error {
 	log.Println("Downloading", object, "to", dest)
+	err := os.MkdirAll(filepath.Dir(dest), 0700)
+	if err != nil {
+		return fmt.Errorf("failed to create destination directory for %q: %w", dest, err)
+	}
 
 	f, err := os.Create(dest)
 	if err != nil {
-		return fmt.Errorf("failed to create file %q, %v", dest, err)
+		return fmt.Errorf("failed to create file %q: %w", dest, err)
 	}
-	defer f.Close()
+	defer func() {
+		closeErr := f.Close()
+		if closeErr != nil {
+			log.Printf("failed to close file %q: %v", dest, closeErr)
+		}
+	}()
+	bucket := os.Getenv("KMSBP_AWS_BUCKET")
 
 	_, err = downloader.Download(f, &s3.GetObjectInput{
-		Bucket: aws.String(os.Getenv("KMSBP_AWS_BUCKET")),
-		Key:    aws.String(object),
+		Bucket: &bucket,
+		Key:    &object,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to upload file, %v", err)
+		return fmt.Errorf("failed to download file: %w", err)
 	}
+
+	return nil
+}
+
+func downloadZipTempFile(downloader *s3manager.Downloader, zipObject string) (string, error) {
+	tmp, err := os.CreateTemp("", "kmsbp-*.zip")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temporary file for zip object %q: %w", zipObject, err)
+	}
+	defer func() {
+		closeErr := tmp.Close()
+		if closeErr != nil {
+			log.Printf("failed to close temporary zip file: %v", closeErr)
+		}
+	}()
+	tmpPath := tmp.Name()
+	bucket := os.Getenv("KMSBP_AWS_BUCKET")
+	var downloadErr error
+	defer func() {
+		if downloadErr != nil {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	_, downloadErr = downloader.Download(tmp, &s3.GetObjectInput{
+		Bucket: &bucket,
+		Key:    &zipObject,
+	})
+	if downloadErr != nil {
+		return "", fmt.Errorf("failed to download zip object %q: %w", zipObject, downloadErr)
+	}
+
+	return tmpPath, nil
+}
+
+func extractZipEntries(zipPath string, items []downloadItem) error {
+	zipReader, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return fmt.Errorf("failed to open zip file %q: %w", zipPath, err)
+	}
+	defer func() {
+		closeErr := zipReader.Close()
+		if closeErr != nil {
+			log.Printf("failed to close zip reader for %q: %v", zipPath, closeErr)
+		}
+	}()
+
+	for _, item := range items {
+		found := false
+		for _, file := range zipReader.File {
+			if file.Name != item.entry {
+				continue
+			}
+			found = true
+
+			if file.FileInfo().IsDir() {
+				return fmt.Errorf("zip entry %q is a directory", item.entry)
+			}
+
+			if file.UncompressedSize64 > maxZipEntrySizeBytes {
+				return fmt.Errorf("zip entry %q exceeds max allowed size of %d bytes", item.entry, maxZipEntrySizeBytes)
+			}
+
+			in, err := file.Open()
+			if err != nil {
+				return fmt.Errorf("failed to open zip entry %q: %w", item.entry, err)
+			}
+			defer func() {
+				closeErr := in.Close()
+				if closeErr != nil {
+					log.Printf("failed to close zip entry %q: %v", item.entry, closeErr)
+				}
+			}()
+
+			err = os.MkdirAll(filepath.Dir(item.dest), 0700)
+			if err != nil {
+				return fmt.Errorf("failed to create destination directory for %q: %w", item.dest, err)
+			}
+
+			out, err := os.Create(item.dest)
+			if err != nil {
+				return fmt.Errorf("failed to create file %q: %w", item.dest, err)
+			}
+			defer func() {
+				closeErr := out.Close()
+				if closeErr != nil {
+					log.Printf("failed to close file %q: %v", item.dest, closeErr)
+				}
+			}()
+
+			_, copyErr := io.CopyN(out, in, int64(maxZipEntrySizeBytes))
+			if copyErr != nil && copyErr != io.EOF {
+				_ = os.Remove(item.dest)
+				return fmt.Errorf("failed to write zip entry %q to %q: %w", item.entry, item.dest, copyErr)
+			}
+
+			log.Println("Downloaded", item.entry, "from", item.obj, "to", item.dest)
+			break
+		}
+
+		if !found {
+			return fmt.Errorf("zip entry %q not found in %q", item.entry, zipPath)
+		}
+	}
+
 	return nil
 }
 

--- a/support/kmsbp/kmsbp_test.go
+++ b/support/kmsbp/kmsbp_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestParseObjectSpec(t *testing.T) {
+	zipSpec := fmt.Sprintf("secrets/bundle.zip%stls/server.crt", zipSpecSeparator)
+	trimmedZipSpec := fmt.Sprintf("  secrets/bundle.zip %s tls/server.crt  ", zipSpecSeparator)
+	missingObjectSpec := zipSpecSeparator + "tls/server.crt"
+	missingEntrySpec := "secrets/bundle.zip" + zipSpecSeparator
+
+	tests := []struct {
+		name      string
+		spec      string
+		wantObj   string
+		wantEntry string
+		wantZip   bool
+		wantErr   bool
+	}{
+		{
+			name:      "plain object",
+			spec:      "certs/root.crt",
+			wantObj:   "certs/root.crt",
+			wantEntry: "",
+			wantZip:   false,
+			wantErr:   false,
+		},
+		{
+			name:      "zip object and entry",
+			spec:      zipSpec,
+			wantObj:   "secrets/bundle.zip",
+			wantEntry: "tls/server.crt",
+			wantZip:   true,
+			wantErr:   false,
+		},
+		{
+			name:      "zip object trims spaces",
+			spec:      trimmedZipSpec,
+			wantObj:   "secrets/bundle.zip",
+			wantEntry: "tls/server.crt",
+			wantZip:   true,
+			wantErr:   false,
+		},
+		{
+			name:    "missing object in zip spec",
+			spec:    missingObjectSpec,
+			wantErr: true,
+		},
+		{
+			name:    "missing entry in zip spec",
+			spec:    missingEntrySpec,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotObj, gotEntry, gotZip, err := parseObjectSpec(tt.spec)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for spec %q", tt.spec)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error for spec %q: %v", tt.spec, err)
+			}
+			if gotObj != tt.wantObj {
+				t.Fatalf("unexpected object for spec %q: got %q want %q", tt.spec, gotObj, tt.wantObj)
+			}
+			if gotEntry != tt.wantEntry {
+				t.Fatalf("unexpected entry for spec %q: got %q want %q", tt.spec, gotEntry, tt.wantEntry)
+			}
+			if gotZip != tt.wantZip {
+				t.Fatalf("unexpected zip flag for spec %q: got %v want %v", tt.spec, gotZip, tt.wantZip)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* Implement support for zip file , so we download consistent files (crt and key of the same generation)
* Implement download plan, so we download the zip file once, otherwise, we still have the same race condition
* Various fixes: add a missing env var in needed vars, fix a typo
* Add CI
* Add tests